### PR TITLE
Add Kuznyechik cipher support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ core
 /gcmdata
 /shadata
 /twofishdata
+/kuzdata
+/kuztable.h
 /keymap.h
 /parity.h
 /rotors.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -156,8 +156,9 @@ nettle_SOURCES = aes-decrypt-internal.c aes-decrypt.c aes-decrypt-table.c \
 		 serpent-set-key.c serpent-encrypt.c serpent-decrypt.c \
 		 serpent-meta.c \
 		 streebog.c streebog-meta.c \
-		 twofish.c twofish-meta.c \
-		 sm4.c sm4-meta.c \
+                twofish.c twofish-meta.c \
+                kuznyechik.c kuznyechik-meta.c \
+                sm4.c sm4-meta.c \
 		 umac-nh.c umac-nh-n.c umac-l2.c umac-l3.c \
 		 umac-poly64.c umac-poly128.c umac-set-key.c \
 		 umac32.c umac64.c umac96.c umac128.c \
@@ -242,7 +243,7 @@ HEADERS = aes.h arcfour.h arctwo.h asn1.h blowfish.h balloon.h \
 	  ocb.h pbkdf2.h \
 	  pgp.h pkcs1.h pss.h pss-mgf1.h realloc.h ripemd160.h rsa.h \
 	  salsa20.h sexp.h serpent.h \
-	  sha.h sha1.h sha2.h sha3.h sm3.h sm4.h streebog.h twofish.h \
+         sha.h sha1.h sha2.h sha3.h sm3.h sm4.h streebog.h kuznyechik.h twofish.h \
 	  umac.h yarrow.h xts.h poly1305.h nist-keywrap.h
 
 INSTALL_HEADERS = $(HEADERS) version.h @IF_MINI_GMP@ mini-gmp.h
@@ -250,7 +251,8 @@ INSTALL_HEADERS = $(HEADERS) version.h @IF_MINI_GMP@ mini-gmp.h
 SOURCES = $(nettle_SOURCES) $(hogweed_SOURCES) \
 	  $(getopt_SOURCES) $(internal_SOURCES) \
 	  $(OPT_SOURCES) \
-	  aesdata.c desdata.c twofishdata.c shadata.c gcmdata.c eccdata.c
+         aesdata.c desdata.c twofishdata.c shadata.c gcmdata.c eccdata.c \
+         kuzdata.c
 
 # NOTE: This list must include all source files, with no duplicates,
 # independently of which source files are included in the build.
@@ -264,8 +266,9 @@ DISTFILES = $(SOURCES) $(HEADERS) getopt.h getopt_int.h \
 	README CONTRIBUTING.md AUTHORS COPYING.LESSERv3 COPYINGv2 COPYINGv3 \
 	INSTALL NEWS ChangeLog \
 	nettle.pc.in hogweed.pc.in \
-	desdata.stamp $(des_headers) descore.README \
-	aes-internal.h block-internal.h blowfish-internal.h bswap-internal.h \
+        desdata.stamp $(des_headers) descore.README \
+       kuztable.h kuzdata.stamp \
+        aes-internal.h block-internal.h blowfish-internal.h bswap-internal.h \
 	camellia-internal.h \
 	ghash-internal.h gost28147-internal.h poly1305-internal.h \
 	serpent-internal.h cast128_sboxes.h desinfo.h desCode.h \
@@ -351,6 +354,15 @@ desdata.stamp: desdata.c
 	echo stamp > desdata.stamp
 
 des.$(OBJEXT): des.c des.h $(des_headers)
+kuztable.h: kuzdata.stamp
+	./kuzdata$(EXEEXT_FOR_BUILD) > $@T && mv $@T $@
+
+kuzdata.stamp: kuzdata.c
+	$(MAKE) kuzdata$(EXEEXT_FOR_BUILD)
+	echo stamp > kuzdata.stamp
+
+kuznyechik.$(OBJEXT): kuztable.h
+
 
 # Generate ECC files, with roughly 16 KB of tables per curve.
 

--- a/examples/nettle-benchmark.c
+++ b/examples/nettle-benchmark.c
@@ -927,6 +927,7 @@ main(int argc, char **argv)
       &nettle_des3,
       &nettle_serpent256,
       &nettle_twofish128, &nettle_twofish192, &nettle_twofish256,
+      &nettle_kuznyechik,
       &nettle_sm4,
       NULL
     };

--- a/kuzdata.c
+++ b/kuzdata.c
@@ -1,0 +1,223 @@
+/*
+   Copyright: 2017 Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>
+
+   This file is part of GNU Nettle.
+
+   GNU Nettle is free software: you can redistribute it and/or
+   modify it under the terms of either:
+
+     * the GNU Lesser General Public License as published by the Free
+       Software Foundation; either version 3 of the License, or (at your
+       option) any later version.
+
+   or
+
+     * the GNU General Public License as published by the Free
+       Software Foundation; either version 2 of the License, or (at your
+       option) any later version.
+
+   or both in parallel, as here.
+
+   GNU Nettle is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received copies of the GNU General Public License and
+   the GNU Lesser General Public License along with this program.  If
+   not, see http://www.gnu.org/licenses/.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+
+#include "macros.h"
+
+static uint8_t pi[256] =
+{
+  0xfc, 0xee, 0xdd, 0x11, 0xcf, 0x6e, 0x31, 0x16,
+  0xfb, 0xc4, 0xfa, 0xda, 0x23, 0xc5, 0x04, 0x4d,
+  0xe9, 0x77, 0xf0, 0xdb, 0x93, 0x2e, 0x99, 0xba,
+  0x17, 0x36, 0xf1, 0xbb, 0x14, 0xcd, 0x5f, 0xc1,
+  0xf9, 0x18, 0x65, 0x5a, 0xe2, 0x5c, 0xef, 0x21,
+  0x81, 0x1c, 0x3c, 0x42, 0x8b, 0x01, 0x8e, 0x4f,
+  0x05, 0x84, 0x02, 0xae, 0xe3, 0x6a, 0x8f, 0xa0,
+  0x06, 0x0b, 0xed, 0x98, 0x7f, 0xd4, 0xd3, 0x1f,
+  0xeb, 0x34, 0x2c, 0x51, 0xea, 0xc8, 0x48, 0xab,
+  0xf2, 0x2a, 0x68, 0xa2, 0xfd, 0x3a, 0xce, 0xcc,
+  0xb5, 0x70, 0x0e, 0x56, 0x08, 0x0c, 0x76, 0x12,
+  0xbf, 0x72, 0x13, 0x47, 0x9c, 0xb7, 0x5d, 0x87,
+  0x15, 0xa1, 0x96, 0x29, 0x10, 0x7b, 0x9a, 0xc7,
+  0xf3, 0x91, 0x78, 0x6f, 0x9d, 0x9e, 0xb2, 0xb1,
+  0x32, 0x75, 0x19, 0x3d, 0xff, 0x35, 0x8a, 0x7e,
+  0x6d, 0x54, 0xc6, 0x80, 0xc3, 0xbd, 0x0d, 0x57,
+  0xdf, 0xf5, 0x24, 0xa9, 0x3e, 0xa8, 0x43, 0xc9,
+  0xd7, 0x79, 0xd6, 0xf6, 0x7c, 0x22, 0xb9, 0x03,
+  0xe0, 0x0f, 0xec, 0xde, 0x7a, 0x94, 0xb0, 0xbc,
+  0xdc, 0xe8, 0x28, 0x50, 0x4e, 0x33, 0x0a, 0x4a,
+  0xa7, 0x97, 0x60, 0x73, 0x1e, 0x00, 0x62, 0x44,
+  0x1a, 0xb8, 0x38, 0x82, 0x64, 0x9f, 0x26, 0x41,
+  0xad, 0x45, 0x46, 0x92, 0x27, 0x5e, 0x55, 0x2f,
+  0x8c, 0xa3, 0xa5, 0x7d, 0x69, 0xd5, 0x95, 0x3b,
+  0x07, 0x58, 0xb3, 0x40, 0x86, 0xac, 0x1d, 0xf7,
+  0x30, 0x37, 0x6b, 0xe4, 0x88, 0xd9, 0xe7, 0x89,
+  0xe1, 0x1b, 0x83, 0x49, 0x4c, 0x3f, 0xf8, 0xfe,
+  0x8d, 0x53, 0xaa, 0x90, 0xca, 0xd8, 0x85, 0x61,
+  0x20, 0x71, 0x67, 0xa4, 0x2d, 0x2b, 0x09, 0x5b,
+  0xcb, 0x9b, 0x25, 0xd0, 0xbe, 0xe5, 0x6c, 0x52,
+  0x59, 0xa6, 0x74, 0xd2, 0xe6, 0xf4, 0xb4, 0xc0,
+  0xd1, 0x66, 0xaf, 0xc2, 0x39, 0x4b, 0x63, 0xb6,
+};
+
+static uint8_t
+MGF2(uint16_t a, uint8_t b)
+{
+  uint16_t s = 0;
+  uint16_t m;
+  uint16_t p;
+
+  for (m = 1; m != 0x100; m <<= 1, a <<= 1)
+    {
+      if (b & m)
+        s ^= a;
+    }
+
+  for (m = 0x8000, p = 0xc3 << 7; m >= 256; m >>= 1, p >>= 1)
+    if (s & m)
+      {
+        s &= ~m;
+        s ^= p;
+      }
+  return s;
+}
+
+static uint8_t larr[16] =
+{
+  1, 148, 32, 133, 16,
+  194, 192, 1, 251, 1, 192,
+  194, 16, 133, 32, 148,
+};
+
+static void
+Linv(uint8_t *a)
+{
+  uint8_t i;
+
+  for (i = 0; i < 16; i++)
+    {
+      uint8_t c = 0;
+      unsigned j;
+
+      for (j = 0; j < 16; j++)
+        c ^= MGF2(larr[j], a[(i + j) % 16]);
+      a[i] = c;
+    }
+}
+
+static void
+L(uint8_t *a)
+{
+  uint8_t i;
+
+  for (i = 15; i < 16; i--)
+    {
+      uint8_t c = 0;
+      unsigned j;
+
+      for (j = 0; j < 16; j++)
+        c ^= MGF2(larr[j], a[(i + j) % 16]);
+      a[i] = c;
+    }
+}
+
+int
+main(void)
+{
+  unsigned i, j, k;
+  uint8_t pi_inv[256];
+
+  printf("static const uint8_t pi[256] =\n{\n  ");
+  for (i = 0; i < 256; i++)
+    {
+      printf("0x%02hhx,%s", pi[i], (i + 1) % 8 ? " " : i == 255 ? "\n" : "\n  ");
+    }
+  printf("};\n\n");
+  for (i = 0; i < 256; i++)
+    pi_inv[pi[i]] = i;
+  printf("static const uint8_t pi_inv[256] =\n{\n  ");
+  for (i = 0; i < 256; i++)
+    {
+      printf("0x%02hhx,%s", pi_inv[i], (i + 1) % 8 ? " " : i == 255 ? "\n" : "\n  ");
+    }
+  printf("};\n\n");
+  printf("static const uint8_t kuz_key_table[32][16] =\n{\n");
+  for (i = 0; i < 32; i++)
+    {
+      uint8_t a[16] = {0};
+      a[15] = i + 1;
+      L(a);
+      printf("  {");
+      for (j = 0; j < 16; j++)
+        printf(" 0x%02hhx,", a[j]);
+      printf("},\n");
+    }
+  printf("};\n\n");
+  printf("static const uint8_t kuz_table[16][256 * 16] =\n{\n");
+  for (i = 0; i < 16; i++)
+    {
+      printf("  { /* %d */\n", i);
+      for (j = 0; j < 256; j++)
+        {
+          uint8_t a[16] = {0};
+
+          a[i] = pi[j];
+          L(a);
+          printf("   ");
+          for (k = 0; k < 16; k++)
+            printf(" 0x%02hhx,", a[k]);
+          printf("\n");
+        }
+      printf("  },\n");
+    }
+  printf("};\n\n");
+  printf("static const uint8_t kuz_table_inv[16][256 * 16] =\n{\n");
+  for (i = 0; i < 16; i++)
+    {
+      printf("  { /* %d */\n", i);
+      for (j = 0; j < 256; j++)
+        {
+          uint8_t a[16] = {0};
+
+          a[i] = j;
+          Linv(a);
+          printf("   ");
+          for (k = 0; k < 16; k++)
+            printf(" 0x%02hhx,", a[k]);
+          printf("\n");
+        }
+      printf("  },\n");
+    }
+  printf("};\n\n");
+  printf("static const uint8_t kuz_table_inv_LS[16][256 * 16] =\n{\n");
+  for (i = 0; i < 16; i++)
+    {
+      printf("  { /* %d */\n", i);
+      for (j = 0; j < 256; j++)
+        {
+          uint8_t a[16] = {0};
+
+          a[i] = pi_inv[j];
+          Linv(a);
+          printf("   ");
+          for (k = 0; k < 16; k++)
+            printf(" 0x%02hhx,", a[k]);
+          printf("\n");
+        }
+      printf("  },\n");
+    }
+  printf("};\n");
+
+  return 0;
+}

--- a/kuznyechik-meta.c
+++ b/kuznyechik-meta.c
@@ -1,6 +1,6 @@
-/* nettle-meta-ciphers.c
+/* kuznyechik-meta.c
 
-   Copyright (C) 2011 Daniel Kahn Gillmor
+   Copyright (C) 2017 Dmitry Eremin-Solenikov
 
    This file is part of GNU Nettle.
 
@@ -33,34 +33,15 @@
 # include "config.h"
 #endif
 
-#include <stddef.h>
 #include "nettle-meta.h"
 
-const struct nettle_cipher * const _nettle_ciphers[] = {
-  &nettle_aes128,
-  &nettle_aes192,
-  &nettle_aes256,
-  &nettle_camellia128,
-  &nettle_camellia192,
-  &nettle_camellia256,
-  &nettle_cast128,
-  &nettle_serpent128,
-  &nettle_serpent192,
-  &nettle_serpent256,
-  &nettle_twofish128,
-  &nettle_twofish192,
-  &nettle_twofish256,
-  &nettle_arctwo40,
-  &nettle_arctwo64,
-  &nettle_arctwo128,
-  &nettle_arctwo_gutmann128,
-  &nettle_kuznyechik,
-  &nettle_sm4,
-  NULL
-};
+#include "kuznyechik.h"
 
-const struct nettle_cipher * const *
-nettle_get_ciphers (void)
-{
-  return _nettle_ciphers;
-}
+const struct nettle_cipher nettle_kuznyechik =
+  { "kuznyechik", sizeof(struct kuznyechik_ctx),
+    KUZNYECHIK_BLOCK_SIZE, KUZNYECHIK_KEY_SIZE,
+    (nettle_set_key_func *) kuznyechik_set_key,
+    (nettle_set_key_func *) kuznyechik_set_key,
+    (nettle_cipher_func *) kuznyechik_encrypt,
+    (nettle_cipher_func *) kuznyechik_decrypt
+  };

--- a/kuznyechik.c
+++ b/kuznyechik.c
@@ -1,0 +1,247 @@
+/* kuznyechik.c - GOST R 34.12-2015 (Kuznyechik) cipher implementation
+
+   Copyright: 2017 Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>
+
+   This file is part of GNU Nettle.
+
+   GNU Nettle is free software: you can redistribute it and/or
+   modify it under the terms of either:
+
+     * the GNU Lesser General Public License as published by the Free
+       Software Foundation; either version 3 of the License, or (at your
+       option) any later version.
+
+   or
+
+     * the GNU General Public License as published by the Free
+       Software Foundation; either version 2 of the License, or (at your
+       option) any later version.
+
+   or both in parallel, as here.
+
+   GNU Nettle is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received copies of the GNU General Public License and
+   the GNU Lesser General Public License along with this program.  If
+   not, see http://www.gnu.org/licenses/.
+ */
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <string.h>
+
+#include "macros.h"
+#include "memxor.h"
+#include "nettle-write.h"
+#include "kuznyechik.h"
+
+#include "kuztable.h"
+
+static void
+S(uint8_t *a, const uint8_t *b)
+{
+  a[0] = pi[b[0]];
+  a[1] = pi[b[1]];
+  a[2] = pi[b[2]];
+  a[3] = pi[b[3]];
+  a[4] = pi[b[4]];
+  a[5] = pi[b[5]];
+  a[6] = pi[b[6]];
+  a[7] = pi[b[7]];
+  a[8] = pi[b[8]];
+  a[9] = pi[b[9]];
+  a[10] = pi[b[10]];
+  a[11] = pi[b[11]];
+  a[12] = pi[b[12]];
+  a[13] = pi[b[13]];
+  a[14] = pi[b[14]];
+  a[15] = pi[b[15]];
+}
+
+static void
+Sinv(uint8_t *a, const uint8_t *b)
+{
+  a[0] = pi_inv[b[0]];
+  a[1] = pi_inv[b[1]];
+  a[2] = pi_inv[b[2]];
+  a[3] = pi_inv[b[3]];
+  a[4] = pi_inv[b[4]];
+  a[5] = pi_inv[b[5]];
+  a[6] = pi_inv[b[6]];
+  a[7] = pi_inv[b[7]];
+  a[8] = pi_inv[b[8]];
+  a[9] = pi_inv[b[9]];
+  a[10] = pi_inv[b[10]];
+  a[11] = pi_inv[b[11]];
+  a[12] = pi_inv[b[12]];
+  a[13] = pi_inv[b[13]];
+  a[14] = pi_inv[b[14]];
+  a[15] = pi_inv[b[15]];
+}
+
+static void
+Linv(uint8_t *a, const uint8_t *b)
+{
+  memcpy(a, &kuz_table_inv[0][b[0] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[1][b[1] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[2][b[2] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[3][b[3] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[4][b[4] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[5][b[5] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[6][b[6] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[7][b[7] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[8][b[8] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[9][b[9] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[10][b[10] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[11][b[11] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[12][b[12] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[13][b[13] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[14][b[14] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(a, &kuz_table_inv[15][b[15] * 16], KUZNYECHIK_BLOCK_SIZE);
+}
+
+static void
+LSX(uint8_t *a, const uint8_t *b, const uint8_t *c)
+{
+  uint8_t t[16];
+
+  memcpy(t, &kuz_table[0][(b[0] ^ c[0]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[1][(b[1] ^ c[1]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[2][(b[2] ^ c[2]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[3][(b[3] ^ c[3]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[4][(b[4] ^ c[4]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[5][(b[5] ^ c[5]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[6][(b[6] ^ c[6]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[7][(b[7] ^ c[7]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[8][(b[8] ^ c[8]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[9][(b[9] ^ c[9]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[10][(b[10] ^ c[10]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[11][(b[11] ^ c[11]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[12][(b[12] ^ c[12]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[13][(b[13] ^ c[13]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table[14][(b[14] ^ c[14]) * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor3(a, t, &kuz_table[15][(b[15] ^ c[15]) * 16], KUZNYECHIK_BLOCK_SIZE);
+}
+
+static void
+XLiSi(uint8_t *a, const uint8_t *b, const uint8_t *c)
+{
+  uint8_t t[16];
+
+  memcpy(t, &kuz_table_inv_LS[0][b[0] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[1][b[1] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[2][b[2] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[3][b[3] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[4][b[4] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[5][b[5] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[6][b[6] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[7][b[7] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[8][b[8] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[9][b[9] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[10][b[10] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[11][b[11] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[12][b[12] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[13][b[13] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[14][b[14] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor(t, &kuz_table_inv_LS[15][b[15] * 16], KUZNYECHIK_BLOCK_SIZE);
+  memxor3(a, t, c, 16);
+}
+
+static void
+subkey(uint8_t *out, const uint8_t *key, unsigned i)
+{
+  uint8_t t[16];
+
+  LSX(t, key + 0,  kuz_key_table[i + 0]);
+  memxor3(out + 16, t, key + 16, 16);
+  LSX(t, out + 16, kuz_key_table[i + 1]);
+  memxor3(out + 0, t, key + 0, 16);
+  LSX(t, out + 0,  kuz_key_table[i + 2]);
+  memxor(out + 16, t, 16);
+  LSX(t, out + 16, kuz_key_table[i + 3]);
+  memxor(out + 0, t, 16);
+  LSX(t, out + 0,  kuz_key_table[i + 4]);
+  memxor(out + 16, t, 16);
+  LSX(t, out + 16, kuz_key_table[i + 5]);
+  memxor(out + 0, t, 16);
+  LSX(t, out + 0,  kuz_key_table[i + 6]);
+  memxor(out + 16, t, 16);
+  LSX(t, out + 16, kuz_key_table[i + 7]);
+  memxor(out + 0, t, 16);
+}
+
+void
+kuznyechik_set_key(struct kuznyechik_ctx *ctx, const uint8_t *key)
+{
+  unsigned i;
+
+  memcpy(ctx->key, key, 32);
+  subkey(ctx->key + 32, ctx->key, 0);
+  subkey(ctx->key + 64, ctx->key + 32, 8);
+  subkey(ctx->key + 96, ctx->key + 64, 16);
+  subkey(ctx->key + 128, ctx->key + 96, 24);
+  for (i = 0; i < 10; i++)
+    Linv(ctx->dekey + 16 * i, ctx->key + 16 * i);
+}
+
+void
+kuznyechik_encrypt(const struct kuznyechik_ctx *ctx,
+                   size_t length, uint8_t *dst,
+                   const uint8_t *src)
+{
+  uint8_t t[KUZNYECHIK_BLOCK_SIZE];
+
+  assert(!(length % KUZNYECHIK_BLOCK_SIZE));
+
+  while (length)
+    {
+      LSX(t, ctx->key + 16 * 0, src);
+      LSX(t, ctx->key + 16 * 1, t);
+      LSX(t, ctx->key + 16 * 2, t);
+      LSX(t, ctx->key + 16 * 3, t);
+      LSX(t, ctx->key + 16 * 4, t);
+      LSX(t, ctx->key + 16 * 5, t);
+      LSX(t, ctx->key + 16 * 6, t);
+      LSX(t, ctx->key + 16 * 7, t);
+      LSX(t, ctx->key + 16 * 8, t);
+      memxor3(dst, ctx->key + 16 * 9, t, 16);
+      src += KUZNYECHIK_BLOCK_SIZE;
+      dst += KUZNYECHIK_BLOCK_SIZE;
+      length -= KUZNYECHIK_BLOCK_SIZE;
+    }
+}
+
+void
+kuznyechik_decrypt(const struct kuznyechik_ctx *ctx,
+                   size_t length, uint8_t *dst,
+                   const uint8_t *src)
+{
+  uint8_t t[KUZNYECHIK_BLOCK_SIZE];
+
+  assert(!(length % KUZNYECHIK_BLOCK_SIZE));
+
+  while (length)
+    {
+      S(t, src);
+      XLiSi(t, t, ctx->dekey + 16 * 9);
+      XLiSi(t, t, ctx->dekey + 16 * 8);
+      XLiSi(t, t, ctx->dekey + 16 * 7);
+      XLiSi(t, t, ctx->dekey + 16 * 6);
+      XLiSi(t, t, ctx->dekey + 16 * 5);
+      XLiSi(t, t, ctx->dekey + 16 * 4);
+      XLiSi(t, t, ctx->dekey + 16 * 3);
+      XLiSi(t, t, ctx->dekey + 16 * 2);
+      XLiSi(t, t, ctx->dekey + 16 * 1);
+      Sinv(dst, t);
+      memxor(dst, ctx->key + 16 * 0, 16);
+      src += KUZNYECHIK_BLOCK_SIZE;
+      dst += KUZNYECHIK_BLOCK_SIZE;
+      length -= KUZNYECHIK_BLOCK_SIZE;
+    }
+}

--- a/kuznyechik.h
+++ b/kuznyechik.h
@@ -1,0 +1,74 @@
+/* kuznyechik.h
+
+   The GOST R 34.12-2015 (Kuznyechik) cipher function.
+
+   Copyright (C) 2017 Dmitry Eremin-Solenikov
+
+   This file is part of GNU Nettle.
+
+   GNU Nettle is free software: you can redistribute it and/or
+   modify it under the terms of either:
+
+     * the GNU Lesser General Public License as published by the Free
+       Software Foundation; either version 3 of the License, or (at your
+       option) any later version.
+
+   or
+
+     * the GNU General Public License as published by the Free
+       Software Foundation; either version 2 of the License, or (at your
+       option) any later version.
+
+   or both in parallel, as here.
+
+   GNU Nettle is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received copies of the GNU General Public License and
+   the GNU Lesser General Public License along with this program.  If
+   not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef NETTLE_KUZNYECHIK_H_INCLUDED
+#define NETTLE_KUZNYECHIK_H_INCLUDED
+
+#include "nettle-types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Name mangling */
+#define kuznyechik_set_key nettle_kuznyechik_set_key
+#define kuznyechik_encrypt nettle_kuznyechik_encrypt
+#define kuznyechik_decrypt nettle_kuznyechik_decrypt
+
+#define KUZNYECHIK_KEY_SIZE 32
+#define KUZNYECHIK_SUBKEYS_SIZE (16 * 10)
+#define KUZNYECHIK_BLOCK_SIZE 16
+
+struct kuznyechik_ctx
+{
+  uint8_t key[KUZNYECHIK_SUBKEYS_SIZE];
+  uint8_t dekey[KUZNYECHIK_SUBKEYS_SIZE];
+};
+
+void
+kuznyechik_set_key(struct kuznyechik_ctx *ctx, const uint8_t *key);
+
+void
+kuznyechik_encrypt(const struct kuznyechik_ctx *ctx,
+                   size_t length, uint8_t *dst,
+                   const uint8_t *src);
+void
+kuznyechik_decrypt(const struct kuznyechik_ctx *ctx,
+                   size_t length, uint8_t *dst,
+                   const uint8_t *src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NETTLE_KUZNYECHIK_H_INCLUDED */

--- a/nettle-meta.h
+++ b/nettle-meta.h
@@ -90,6 +90,7 @@ extern const struct nettle_cipher nettle_arctwo128;
 extern const struct nettle_cipher nettle_arctwo_gutmann128;
 
 extern const struct nettle_cipher nettle_sm4;
+extern const struct nettle_cipher nettle_kuznyechik;
 
 struct nettle_hash
 {

--- a/testsuite/.gitignore
+++ b/testsuite/.gitignore
@@ -99,6 +99,7 @@
 /sha512-256-test
 /sha512-test
 /sm3-test
+/kuznyechik-test
 /sm4-test
 /streebog-test
 /twofish-test

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -24,7 +24,7 @@ TS_NETTLE_SOURCES = aes-test.c aes-keywrap-test.c arcfour-test.c arctwo-test.c \
 		    sha384-test.c sha512-test.c sha512-224-test.c sha512-256-test.c \
 		    sha3-permute-test.c sha3-224-test.c sha3-256-test.c \
 		    sha3-384-test.c sha3-512-test.c \
-		    shake256-test.c streebog-test.c sm3-test.c sm4-test.c \
+                    shake256-test.c streebog-test.c sm3-test.c kuznyechik-test.c sm4-test.c \
 		    serpent-test.c twofish-test.c version-test.c \
 		    knuth-lfib-test.c \
 		    cbc-test.c cfb-test.c ctr-test.c gcm-test.c eax-test.c ccm-test.c \

--- a/testsuite/kuznyechik-test.c
+++ b/testsuite/kuznyechik-test.c
@@ -1,0 +1,75 @@
+#include "testutils.h"
+#include "kuznyechik.h"
+#include "cfb.h"
+
+void
+test_main(void)
+{
+  test_cipher(&nettle_kuznyechik,
+              SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+              SHEX("1122334455667700ffeeddccbbaa9988"
+                   "00112233445566778899aabbcceeff0a"
+                   "112233445566778899aabbcceeff0a00"
+                   "2233445566778899aabbcceeff0a0011"),
+              SHEX("7f679d90bebc24305a468d42b9d4edcd"
+                   "b429912c6e0032f9285452d76718d08b"
+                   "f0ca33549d247ceef3f5a5313bd4b157"
+                   "d0b09ccde830b9eb3a02c4c5aa8ada98"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+              SHEX("1234567890abcef00000000000000000"),
+              SHEX("e0b7ebfa9468a6db2a95826efb173830"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+              SHEX("1234567890abcef00000000000000001"),
+              SHEX("85ffc500b2f4582a7ba54e08f0ab21ee"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+              SHEX("1234567890abcef00000000000000002"),
+              SHEX("b4c8dbcfb353195b4c42cc3ddb9ba9a5"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+              SHEX("1234567890abcef00000000000000003"),
+              SHEX("e9a2bee4947b322f7b7d1db6dfb7ba62"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("2666ed40ae687811745ca0b448f57a7b390adb5780307e8e9659ac403ae60c60"),
+              SHEX("1234567890abcef00000000000000002"),
+              SHEX("5aecd8cb31093bdd99bdbdebb07ae200"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("2666ed40ae687811745ca0b448f57a7b390adb5780307e8e9659ac403ae60c60"),
+              SHEX("1234567890abcef00000000000000003"),
+              SHEX("7a4f09a00ea71ca094f3f8412f8a5057"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("bb3dd5402e999b7a3debb0db45448ec530f07365dfee3aba8415f77ac8f34ce8"),
+              SHEX("1234567890abcef00000000000000004"),
+              SHEX("fc74a010f126754ba73082ce618a984c"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("bb3dd5402e999b7a3debb0db45448ec530f07365dfee3aba8415f77ac8f34ce8"),
+              SHEX("1234567890abcef00000000000000005"),
+              SHEX("9ba8619b09af9cfdc0a1c47e3432340d"));
+
+  test_cipher(&nettle_kuznyechik,
+              SHEX("23362fd553cad2178299a5b5a2d4722e3bb83c730a8bf57ce2dd004017f8c565"),
+              SHEX("1234567890abcef00000000000000006"),
+              SHEX("316fde4a1b507318872d2be7eaf4ed19"));
+
+  test_cipher_ctr(&nettle_kuznyechik,
+                  SHEX("8899aabbccddeeff0011223344556677fedcba98765432100123456789abcdef"),
+                  SHEX("1122334455667700ffeeddccbbaa9988"
+                       "00112233445566778899aabbcceeff0a"
+                       "112233445566778899aabbcceeff0a00"
+                       "2233445566778899aabbcceeff0a0011"),
+                  SHEX("f195d8bec10ed1dbd57b5fa240bda1b8"
+                       "85eee733f6a13e5df33ce4b33c45dee4"
+                       "a5eae88be6356ed3d5e877f13564a3a5"
+                       "cb91fab1f20cbab6d1c6d15820bdba73"),
+                  SHEX("1234567890abcef00000000000000000"));
+}

--- a/testsuite/meta-cipher-test.c
+++ b/testsuite/meta-cipher-test.c
@@ -20,6 +20,7 @@ const char* ciphers[] = {
   "twofish128",
   "twofish192",
   "twofish256",
+  "kuznyechik",
   "sm4"
 };
 


### PR DESCRIPTION
## Summary
- port Kuznyechik (GOST R 34.12-2015) block cipher
- generate lookup tables via `kuzdata.c`
- integrate cipher with build and examples
- provide tests for Kuznyechik

## Testing
- `apt-get update`
- `apt-get install -y ed`

------
https://chatgpt.com/codex/tasks/task_e_6884a722277c832e920d2dad34c7f581